### PR TITLE
Minor fix in the React-Native-keyEvent

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -5,7 +5,6 @@ config("LibRNKeyEventModule_config") {
     "-Wno-extra-semi",
     "-Wno-sign-compare",
     "-Wno-header-hygiene",
-    "-Wno-inconsistent-missing-override"
   ]
 
   include_dirs = [

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -5,6 +5,7 @@ config("LibRNKeyEventModule_config") {
     "-Wno-extra-semi",
     "-Wno-sign-compare",
     "-Wno-header-hygiene",
+    "-Wno-inconsistent-missing-override"
   ]
 
   include_dirs = [

--- a/skia/RNKeyEventModule.h
+++ b/skia/RNKeyEventModule.h
@@ -26,8 +26,8 @@ class RNKeyEventModule : public NativeEventEmitterModule {
 
  private:
   int callbackId_ = 0;
-  void startObserving();
-  void stopObserving();
+  void startObserving()override;
+  void stopObserving()override;
   unsigned int repeatCount_=0;
   folly::dynamic generateEventPayload(react::RSkKeyInput keyInput,unsigned int repeatCount = 0);
 };


### PR DESCRIPTION
#1 startObserving & stopObserving API's are virtual functions missed to add override the derived class. 